### PR TITLE
Wait until device is connected, delete profile if connection fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ wifi.scan(function(err, networks) {
               channel: <number>,
               frequency: <number>, // in MHz
               signal_level: <number>, // in dB
-              security: 'WPA WPA2' //
+              security: 'WPA WPA2' // format depending on locale for open networks in Windows
               security_flags: '...' // encryption protocols (format currently depending of the OS)
               mode: '...' // network mode like Infra (format currently depending of the OS)
             },
@@ -86,8 +86,7 @@ wifi.disconnect(function(err) {
     console.log('Disconnected');
 });
 
-// Disconnect from a network
-// not available on all os for now
+// List the current wifi connections
 wifi.getCurrentConnections(function(err, currentConnections) {
     if (err) {
         console.log(err);

--- a/src/windows-current-connections.js
+++ b/src/windows-current-connections.js
@@ -57,7 +57,6 @@ function parseShowInterfaces (stdout, config) {
             security_flags: tmpConnection['encryption'],
         })
 
-
         i = i + 18;
     }
 
@@ -80,22 +79,20 @@ function getCurrentConnection(config, callback) {
     });
 }
 
-
 module.exports = function (config) {
-
     return function(callback) {
-      if (callback) {
-        getCurrentConnection(config, callback);
-      } else {
-        return new Promise(function (resolve, reject) {
-          getCurrentConnection(config, function (err, connections) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(connections);
-            }
-          })
-        });
-      }
+        if (callback) {
+            getCurrentConnection(config, callback);
+        } else {
+            return new Promise(function (resolve, reject) {
+                getCurrentConnection(config, function (err, connections) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(connections);
+                    }
+                })
+            });
+        }
     }
 }

--- a/src/windows-disconnect.js
+++ b/src/windows-disconnect.js
@@ -13,18 +13,18 @@ function disconnect (config, callback) {
 
 module.exports = function (config) {
     return function(callback) {
-      if (callback) {
-        disconnect(config, callback);
-      } else {
-        return new Promise(function (resolve, reject) {
-          disconnect(config, function (err) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          })
-        })
-      }
+        if (callback) {
+            disconnect(config, callback);
+        } else {
+            return new Promise(function (resolve, reject) {
+                disconnect(config, function (err) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                })
+            })
+        }
     }
 }

--- a/src/windows-scan.js
+++ b/src/windows-scan.js
@@ -24,7 +24,6 @@ function scanWifi(config, callback) {
                 if (scanResults[i] === '') {
                     numNetworks++;
                     networkTmp = scanResults.slice(currentLine, i);
-                    console.log("networkTmp", networkTmp);
                     networksTmp.push(networkTmp);
                     currentLine = i+1;
                 }

--- a/src/windows-scan.js
+++ b/src/windows-scan.js
@@ -3,86 +3,75 @@ var networkUtils = require('./network-utils');
 var env = require('./env');
 
 function scanWifi(config, callback) {
-	var networks = [];
-	var network = {};
-	try {
-		exec("chcp 65001 && netsh wlan show networks mode=Bssid", env, function(err, scanResults) {
-			try {
-                if (err) {
-                    callback && callback(err);
-                    return;
-                }
-
-                scanResults = scanResults.toString('utf8')/*.split(' ').join('')*/.split('\r').join('').split('\n').slice(5, scanResults.length);
-
-                var numNetworks = -1;
-                var currentLine = 0;
-                var networkTmp;
-                var networksTmp = [];
-                var network;
-                var networks = [];
-
-                for (var i = 0; i < scanResults.length; i++) {
-                    if (scanResults[i] == '') {
-                        numNetworks++;
-                        networkTmp = scanResults.slice(currentLine, i);
-                        networksTmp.push(networkTmp);
-                        currentLine = i+1;
-                    }
-                }
-
-                for (var i = 0; i < numNetworks; i++) {
-                    network = parse(networksTmp[i]);
-                    networks.push(network);
-                }
-                var resp = networks;
-                callback && callback(null, resp);
-            } catch (e) {
-                callback && callback(e);
+    try {
+        exec("chcp 65001 && netsh wlan show networks mode=Bssid", env, function(err, scanResults) {
+            if (err) {
+                callback && callback(err);
+                return;
             }
-		});
-	} catch (e) {
-		callback && callback(e);
-	}
 
+            scanResults = scanResults.toString('utf8').split('\r').join('').split('\n').slice(5, scanResults.length);
+
+            var numNetworks = -1;
+            var currentLine = 0;
+            var networkTmp;
+            var networksTmp = [];
+            var network;
+            var networks = [];
+            var i;
+
+            for (i = 0; i < scanResults.length; i++) {
+                if (scanResults[i] === '') {
+                    numNetworks++;
+                    networkTmp = scanResults.slice(currentLine, i);
+                    console.log("networkTmp", networkTmp);
+                    networksTmp.push(networkTmp);
+                    currentLine = i+1;
+                }
+            }
+
+            for (i = 0; i < numNetworks; i++) {
+                network = parse(networksTmp[i]);
+                networks.push(network);
+            }
+
+            callback && callback(null, networks);
+        });
+    } catch (e) {
+        callback && callback(e);
+    }
 }
 
 function parse(networkTmp) {
-	var network = {
-		mac : null,
-		ssid : null,
-		frequency : null,
-		signal_level : null,
-		security : null,
-	};
-	network.mac = networkTmp[4].match(/.*?:\s(.*)/)[1];
-	network.bssid = network.mac;
-	network.ssid = networkTmp[0].match(/.*?:\s(.*)/)[1];
-	network.channel = parseInt(networkTmp[7].match(/.*?:\s(.*)/)[1]);
-	network.frequency = parseInt(networkUtils.frequencyFromChannel(network.channel));
-	network.signal_level = networkUtils.dBFromQuality(networkTmp[5].match(/.*?:\s(.*)/)[1]);
-	network.security = networkTmp[2].match(/.*?:\s(.*)/)[1];
-	network.security_flags = networkTmp[3].match(/.*?:\s(.*)/)[1];
-	network.mode = 'Unknown';
+    var network = {};
 
-	return network;
+    network.mac = networkTmp[4].match(/.*?:\s(.*)/)[1];
+    network.bssid = network.mac;
+    network.ssid = networkTmp[0].match(/.*?:\s(.*)/)[1];
+    network.channel = parseInt(networkTmp[7].match(/.*?:\s(.*)/)[1]);
+    network.frequency = parseInt(networkUtils.frequencyFromChannel(network.channel));
+    network.signal_level = networkUtils.dBFromQuality(networkTmp[5].match(/.*?:\s(.*)/)[1]);
+    network.security = networkTmp[2].match(/.*?:\s(.*)/)[1];
+    network.security_flags = networkTmp[3].match(/.*?:\s(.*)/)[1];
+    network.mode = 'Unknown';
 
+    return network;
 }
 
 module.exports = function (config) {
-  return function (callback) {
-    if (callback) {
-      scanWifi(config, callback);
-    } else {
-      return new Promise(function (resolve, reject) {
-        scanWifi(config, function (err, networks) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(networks);
-          }
-        });
-      });
+    return function (callback) {
+        if (callback) {
+            scanWifi(config, callback);
+        } else {
+            return new Promise(function (resolve, reject) {
+                scanWifi(config, function (err, networks) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(networks);
+                    }
+                });
+            });
+        }
     }
-  }
 };


### PR DESCRIPTION
We are using this library in Windows, and we detected that `connectToWifi`'s callback is called when Windows is told to connect to the network instead of waiting for it to actually connect.

I changed its behaviour, so it waits until `netsh wlan connect` is done and the profile XML is deleted.

Additionally, if the connection fails, the function also takes care of deleting the created connection profile.