### PR TITLE
getCurrentConnections fixed for Mac OS

### DIFF
--- a/src/mac-current-connections.js
+++ b/src/mac-current-connections.js
@@ -31,7 +31,7 @@ function parseAirport (stdout) {
     return connections;
 }
 
-function getCurrentConnections(config, callback) {
+function getCurrentConnections(callback) {
   var commandStr = macProvider+" --getinfo" ;
 
   exec(commandStr, env, function(err, stdout) {


### PR DESCRIPTION
Fixed issue where callback passed to getCurrentConnections wasn't being called.