### PR TITLE
correctly return error if network is not found

### DIFF
--- a/src/mac-connect.js
+++ b/src/mac-connect.js
@@ -17,6 +17,8 @@ function connectToWifi(config, ap, callback) {
     //console.log(stderr, resp);
     if (resp && resp.indexOf('Failed to join network') >= 0) {
       callback && callback(resp);
+    } else if (resp && resp.indexOf('Could not find network') >= 0) {
+      callback && callback(resp);
     } else {
       callback && callback(err);
     }


### PR DESCRIPTION
When trying to connect to a wifi that was not there in the first place. The method returned a success instead of error.