### PR TITLE
Fixed Windows netsh missing argument problem

### DIFF
--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -36,7 +36,7 @@ function connectToWifi(config, ap, callback) {
             return execCommand("netsh wlan add profile filename=\"" + ap.ssid + ".xml\"")
         })
         .then(function() {
-            return execCommand("netsh wlan connect ssid=\"" + ap.ssid + "\" name=\"" + ap.ssid + "\"");
+            return execCommand("netsh wlan connect ssid=\"" + ap.ssid + "\" name=\"" + ap.ssid + "\" interface=\"" + config.iface + "\"");
         })
         .then(function() {
             return execCommand("del \".\\" + ap.ssid + ".xml\"");


### PR DESCRIPTION
I was having problems to connect to a network using my 2nd wi-fi interface on Windows 10.

I executed the command manualy and the error seemed to be a missing argument. Than noticed that passing the `interface="intf"` argument, the command works. I think it's because I have more than one interfaces connected to my pc, so I have to tell `netsh` what interface I want to use.

Already tested this PR in my PC, and it's working. I don't think this extra argument could impact other behaviours.