### PR TITLE
resolves issue where linux can't connect if appostrophes in ap/password

### DIFF
--- a/src/linux-connect.js
+++ b/src/linux-connect.js
@@ -7,8 +7,8 @@ var escapeShell = function(cmd) {
 };
 
 function connectToWifi(config, ap, callback) {
-  var commandStr = "nmcli -w 10 device wifi connect '" + ap.ssid + "'" +
-      " password " + "'" + ap.password + "'" ;
+  var commandStr = "nmcli -w 10 device wifi connect \"" + ap.ssid + "\"" +
+      " password " + "\"" + ap.password + "\"" ;
 
   if (config.iface) {
       commandStr = commandStr + " ifname " + config.iface;


### PR DESCRIPTION
this resolves any instance where an access point has an apostrophe in the ssid (typical for any iPhone hotspots for instance).