### PR TITLE
fix child_process.exec options format

### DIFF
--- a/src/linux-connect.js
+++ b/src/linux-connect.js
@@ -16,7 +16,7 @@ function connectToWifi(config, ap, callback) {
 
     // commandStr = escapeShell(commandStr);
 
-  exec(commandStr, env, function(err, resp) {
+  exec(commandStr, {env}, function(err, resp) {
       callback && callback(err);
   });
 }

--- a/src/linux-current-connections.js
+++ b/src/linux-current-connections.js
@@ -8,7 +8,7 @@ function getCurrentConnection(config, callback) {
       commandStr += ' list ifname '+config.iface;
   }
 
-  exec(commandStr, env, function(err, scanResults) {
+  exec(commandStr, {env}, function(err, scanResults) {
       if (err) {
         callback && callback(err);
         return;

--- a/src/linux-disconnect.js
+++ b/src/linux-disconnect.js
@@ -7,8 +7,8 @@ function disconnect (config, callback) {
   if (config.iface) {
       commandStr += " " + config.iface;
   }
-  
-  exec(commandStr, env, function(err, resp) {
+
+  exec(commandStr, {env}, function(err, resp) {
       callback && callback(err);
   });
 

--- a/src/linux-scan.js
+++ b/src/linux-scan.js
@@ -8,7 +8,7 @@ function scanWifi(config, callback) {
       commandStr += ' ifname '+config.iface;
   }
 
-  exec(commandStr, env, function(err, scanResults) {
+  exec(commandStr, {env}, function(err, scanResults) {
       if (err) {
         callback && callback(err);
         return;

--- a/src/mac-connect.js
+++ b/src/mac-connect.js
@@ -13,7 +13,7 @@ function connectToWifi(config, ap, callback) {
   commandStr = commandStr + "'" + iface + "'" + " " + "'" + ap.ssid + "'" + " " + "'" + ap.password + "'";
   //console.log(commandStr);
 
-  exec(commandStr, env, function(err, resp, stderr) {
+  exec(commandStr, {env}, function(err, resp, stderr) {
     //console.log(stderr, resp);
     if (resp && resp.indexOf('Failed to join network') >= 0) {
       callback && callback(resp);

--- a/src/mac-current-connections.js
+++ b/src/mac-current-connections.js
@@ -35,7 +35,7 @@ function parseAirport (stdout) {
 function getCurrentConnections(config, callback) {
   var commandStr = macProvider+" --getinfo" ;
 
-  exec(commandStr, env, function(err, stdout) {
+  exec(commandStr, {env}, function(err, stdout) {
         if (err) {
             callback && callback(err);
         } else {

--- a/src/mac-scan.js
+++ b/src/mac-scan.js
@@ -8,7 +8,7 @@ function scanWifi(config, callback) {
   var networks = []
   var network = {}
 
-  exec(macProvider + ' -s', env,  function(err, scanResults) {
+  exec(macProvider + ' -s', {env},  function(err, scanResults) {
 
       if (err) {
           callback && callback(err);

--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -5,7 +5,7 @@ var scan = require('./windows-scan');
 
 function execCommand(cmd) {
     return new Promise(function(resolve, reject) {
-        exec(cmd, env, function(err, stdout, stderr) {
+        exec(cmd, {env}, function(err, stdout, stderr) {
             if (err) {
                 // Add command output to error, so it's easier to handle
                 err.stdout = stdout;
@@ -49,7 +49,7 @@ function connectToWifi(config, ap, callback) {
             callback && callback();
         })
         .catch(function(err) {
-            exec('netsh wlan delete profile "' + ap.ssid + '"', env, function() {
+            exec('netsh wlan delete profile "' + ap.ssid + '"', {env}, function() {
                 callback && callback(err);
             });
         });

--- a/src/windows-current-connections.js
+++ b/src/windows-current-connections.js
@@ -66,7 +66,7 @@ function parseShowInterfaces (stdout, config) {
 
 function getCurrentConnection(config, callback) {
     var commandStr = "netsh wlan show interfaces" ;
-    exec(commandStr, env, function(err, stdout) {
+    exec(commandStr, {env}, function(err, stdout) {
         if (err) {
             callback && callback(err);
         } else {

--- a/src/windows-disconnect.js
+++ b/src/windows-disconnect.js
@@ -6,7 +6,7 @@ function disconnect (config, callback) {
     if (config.iface) {
         cmd += ' interface="' + config.iface + '"'
     }
-    exec(cmd, env, function(err, resp) {
+    exec(cmd, {env}, function(err, resp) {
         callback && callback(err);
     });
 }

--- a/src/windows-scan.js
+++ b/src/windows-scan.js
@@ -4,7 +4,7 @@ var env = require('./env');
 
 function scanWifi(config, callback) {
     try {
-        exec("chcp 65001 && netsh wlan show networks mode=Bssid", env, function(err, scanResults) {
+        exec("chcp 65001 && netsh wlan show networks mode=Bssid", {env}, function(err, scanResults) {
             if (err) {
                 callback && callback(err);
                 return;


### PR DESCRIPTION
The `env` should be a property of an options Object and should not be passed directly. By sending it directly it will clash with other libraries that are trying to override `exec` `Options`. In my case, this is `pkg` library, see: https://github.com/zeit/pkg/blob/master/prelude/bootstrap.js#L1336
See `child_process.exec` docs: https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback