### PR TITLE
sanity check for colon

### DIFF
--- a/src/linux-scan.js
+++ b/src/linux-scan.js
@@ -22,7 +22,7 @@ function scanWifi(config, callback) {
 
       var networks = [];
       for (var i = 0 ; i < lines.length ; i++) {
-        if (lines[i] != '') {
+        if (lines[i] != '' && lines[i].includes(":")) {
           var fields = lines[i].replace(/\\\:/g, '&&').split(':');
           if (fields.length >= 9) {
             networks.push({


### PR DESCRIPTION
in some platforms (raspberry pi for instance) providing the iface option prepends that same iface declaration to the output. this is hanging up this loop as the very next line assumes every line has colons. this quick check will skip any lines without required colon delimiters.