### PR TITLE
List all BSSIDs for each SSID, on Windows

### DIFF
--- a/src/network-utils.js
+++ b/src/network-utils.js
@@ -52,3 +52,4 @@ function qualityFromDB(db) {
 
 exports.frequencyFromChannel = frequencyFromChannel;
 exports.dBFromQuality = dBFromQuality;
+exports.qualityFromDB = qualityFromDB;


### PR DESCRIPTION
I was expecting `node-wifi` to return all the SSIDS and BSSIDS also on Windows as it does on macOS.

On macOS it returns something like this:
```
[ { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Pingu',
    channel: 11,
    frequency: 2462,
    signal_level: -56.5,
    quality: 1,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Pingu',
    channel: 36,
    frequency: 5180,
    signal_level: -56.5,
    quality: 6,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Pingu',
    channel: 100,
    frequency: 5500,
    signal_level: -58,
    quality: 6,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Pingu',
    channel: 11,
    frequency: 2462,
    signal_level: -51.5,
    quality: 97,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Koti_5DE1',
    channel: 1,
    frequency: 2412,
    signal_level: -91,
    quality: 18,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'TP-Link',
    channel: 2,
    frequency: 2417,
    signal_level: -80,
    quality: 40,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'DNA-WLAN-A5CBA4',
    channel: 6,
    frequency: 2437,
    signal_level: -89,
    quality: 22,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'DNA-WLAN-2G-A5CBA4',
    channel: 6,
    frequency: 2437,
    signal_level: -89,
    quality: 22,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' } ]
```

On Windows it used to return only:
```
 [ { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Pingu',
    channel: 11,
    frequency: 2462,
    signal_level: -51.5,
    quality: 97,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Koti_5DE1',
    channel: 1,
    frequency: 2412,
    signal_level: -91,
    quality: 18,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'TP-Link',
    channel: 2,
    frequency: 2417,
    signal_level: -80,
    quality: 40,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'DNA-WLAN-A5CBA4',
    channel: 6,
    frequency: 2437,
    signal_level: -89,
    quality: 22,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'DNA-WLAN-2G-A5CBA4',
    channel: 6,
    frequency: 2437,
    signal_level: -89,
    quality: 22,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' },
  { mac: 'mac',
    bssid: 'bssid',
    ssid: 'Koti_5DE1_5G',
    channel: 36,
    frequency: 5180,
    signal_level: -87,
    quality: 26,
    security: 'WPA2-Personal',
    security_flags: 'CCMP ',
    mode: 'Unknown' } ]
```


But after my modification, it will return all the BSSIDs for each SSID as well, since I need this kind of behaviour on my other project.