### PR TITLE
Fixes getCurrentConnections in Mac OS

### DIFF
--- a/src/network-utils.js
+++ b/src/network-utils.js
@@ -52,3 +52,4 @@ function qualityFromDB(db) {
 
 exports.frequencyFromChannel = frequencyFromChannel;
 exports.dBFromQuality = dBFromQuality;
+exports.qualityFromDB = qualityFromDB;


### PR DESCRIPTION
Right now `getCurrentConnections` in Mac OS is broken.  We have an exception when getting current connections
![image](https://user-images.githubusercontent.com/1263856/57185088-b3a52e80-6e8a-11e9-8004-d6ce066053e9.png)

This little change fixes the issue an makes the library works in Mac OS. 

Fixes https://github.com/friedrith/node-wifi/issues/65 
Also, make this PR unnecessary https://github.com/friedrith/node-wifi/pull/67