### PR TITLE
fixed empty network fields parsing as per #72

### DIFF
--- a/src/windows-scan.js
+++ b/src/windows-scan.js
@@ -30,8 +30,11 @@ function scanWifi(config, callback) {
             }
 
             for (i = 0; i < numNetworks; i++) {
-                network = parse(networksTmp[i]);
-                networks.push(network);
+                // skip empty networks
+                if (networksTmp[i] && networksTmp[i].length > 0) {
+                    network = parse(networksTmp[i]);
+                    networks.push(network);
+                }
             }
 
             callback && callback(null, networks);
@@ -44,15 +47,15 @@ function scanWifi(config, callback) {
 function parse(networkTmp) {
     var network = {};
 
-    network.mac = networkTmp[4].match(/.*?:\s(.*)/)[1];
+    network.mac = networkTmp[4] ? networkTmp[4].match(/.*?:\s(.*)/)[1] : "";
     network.bssid = network.mac;
-    network.ssid = networkTmp[0].match(/.*?:\s(.*)/)[1];
-    network.channel = parseInt(networkTmp[7].match(/.*?:\s(.*)/)[1]);
-    network.frequency = parseInt(networkUtils.frequencyFromChannel(network.channel));
-    network.signal_level = networkUtils.dBFromQuality(networkTmp[5].match(/.*?:\s(.*)/)[1]);
-    network.quality = parseFloat(networkTmp[5].match(/.*?:\s(.*)/)[1]);
-    network.security = networkTmp[2].match(/.*?:\s(.*)/)[1];
-    network.security_flags = networkTmp[3].match(/.*?:\s(.*)/)[1];
+    network.ssid = networkTmp[0] ? networkTmp[0].match(/.*?:\s(.*)/)[1] : "";
+    network.channel = networkTmp[7] ? parseInt(networkTmp[7].match(/.*?:\s(.*)/)[1]) : -1;
+    network.frequency = network.channel ? parseInt(networkUtils.frequencyFromChannel(network.channel)) : 0;
+    network.signal_level = networkTmp[5] ? networkUtils.dBFromQuality(networkTmp[5].match(/.*?:\s(.*)/)[1]): Number.MIN_VALUE;
+    network.quality = networkTmp[5] ? parseFloat(networkTmp[5].match(/.*?:\s(.*)/)[1]) : 0;
+    network.security = networkTmp[2] ? networkTmp[2].match(/.*?:\s(.*)/)[1] : "";
+    network.security_flags = networkTmp[3] ? networkTmp[3].match(/.*?:\s(.*)/)[1] : "";
     network.mode = 'Unknown';
 
     return network;


### PR DESCRIPTION
- avoid parsing empty networks.
- verify that each network field is defined before trying to parse it.