### PR TITLE
fix: windows network profile adding issue

### DIFF
--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -37,7 +37,7 @@ function connectToWifi(config, ap, callback) {
     })
     .then(function() {
       return execCommand(
-        'netsh wlan add profile filename="' + ap.ssid + '.xml"'
+        'netsh wlan add profile filename="nodeWifiConnect.xml"'
       );
     })
     .then(function() {


### PR DESCRIPTION
fix: windows network profile adding issue

It was unable to connect to a wifi network using this library because the profile that was created was incorrectly named.

Fixes issue #78 
