### PR TITLE
fix: windows connection profile execute

### DIFF
--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -37,7 +37,7 @@ function connectToWifi(config, ap, callback) {
     })
     .then(function() {
       return execCommand(
-        'netsh wlan add profile filename="' + ap.ssid + '.xml"'
+        'netsh wlan add profile filename="nodeWifiConnect.xml"'
       );
     })
     .then(function() {


### PR DESCRIPTION
The network profile add command is being executed with wrong filename.
Fixes issue #78