### PR TITLE
fix: adapt chalk string syntax

### DIFF
--- a/bin/wifi.js
+++ b/bin/wifi.js
@@ -18,34 +18,34 @@ const optionDefinitions = [
   {
       name: 'connect',
       type: Boolean,
-      description: 'Connect to a wifi network. It needs options [bold]{--ssid} and [bold]{--password}. A specific interface may be selected by adding option [bold]{--iface}'
+      description: 'Connect to a wifi network. It needs options {bold --ssid} and {bold --password}. A specific interface may be selected by adding option {bold --iface}'
   },
   {
       name: 'disconnect',
       type: Boolean,
-      description: 'Disconnect from a wifi network. A specific interface may be selected by adding option [bold]{--iface}'
+      description: 'Disconnect from a wifi network. A specific interface may be selected by adding option {bold --iface}'
   },
   {
       name: 'current',
       type: Boolean,
-      description: 'List the current wifi connections. A specific interface may be selected by adding option [bold]{--iface}'
+      description: 'List the current wifi connections. A specific interface may be selected by adding option {bold --iface}'
   },
   {
       name: 'ssid',
       type: String,
-      typeLabel: '[underline]{ssid}',
+      typeLabel: '{underline ssid}',
       description: 'Ssid to connect to the wifi.'
   },
   {
       name: 'password',
       type: String,
-      typeLabel: '[underline]{password}',
+      typeLabel: '{underline password}',
       description: 'Password to connect to the wifi.'
   },
   {
       name: 'iface',
       type: String,
-      typeLabel: '[underline]{interface}',
+      typeLabel: '{underline interface}',
       description: 'Network interface to connect to the wifi.'
   },
   {


### PR DESCRIPTION
Fixes broken CLI.

Following error message appear when installing a fresh version of  node-wifi and using  the cli:

```
/node-wifi/node_modules/chalk/templates.js:109
				throw new Error('Found extraneous } in Chalk template literal');
				^

Error: Found extraneous } in Chalk template literal
```

The string syntax was adopted to the latest [chalk](https://github.com/chalk/chalk) syntax.

## Motivation and Context

Make the CLI usable again.

## Usage examples

```
wifi --scan
```

## How Has This Been Tested?

Manual tests on Linux and MacOS.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
