### PR TITLE
fixing windows connect implementation #89

### DIFF
--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -44,7 +44,7 @@ function connectToWifi(config, ap, callback) {
       ]);
     })
     .then(function() {
-      var cmd = 'cmd';
+      var cmd = 'netsh';
       var params = [
         'wlan',
         'connect',


### PR DESCRIPTION
Current windows connect implementation is broken. This commit fixes it.
