### PR TITLE
Added the missing Mac disconnect functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.13](https://github.com/friedrith/node-wifi/compare/v2.0.12...v2.0.13) (2019-11-16)
+
 ### [2.0.12](https://github.com/friedrith/node-wifi/compare/v2.0.11...v2.0.12) (2019-09-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.14](https://github.com/friedrith/node-wifi/compare/v2.0.13...v2.0.14) (2019-11-16)
+
 ### [2.0.13](https://github.com/friedrith/node-wifi/compare/v2.0.12...v2.0.13) (2019-11-16)
 
 ### [2.0.12](https://github.com/friedrith/node-wifi/compare/v2.0.11...v2.0.12) (2019-09-06)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-wifi",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-wifi",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-wifi",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "NodeJS tool to manage wifi",
   "bin": {
     "wifi": "bin/wifi.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-wifi",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "NodeJS tool to manage wifi",
   "bin": {
     "wifi": "bin/wifi.js"

--- a/src/mac-disconnect.js
+++ b/src/mac-disconnect.js
@@ -1,0 +1,62 @@
+var execFile = require('child_process').execFile;
+var env = require('./env');
+
+// sleep function is required to delay the two commands without breaking into a promise (like with setTimeout)
+function sleep(milliseconds) {
+  var start = new Date().getTime();
+  for (var i = 0; i < 1e7; i++) {
+    if ((new Date().getTime() - start) > milliseconds){
+      break;
+    }
+  }
+}
+
+async function disconnect(config, callback) {
+  var iface = 'en0';
+  var delay = 0;
+  var option = '-setairportpower';
+
+  if (config.iface) {
+    iface = config.iface.toString();
+  }
+  if (config.delay) {
+    delay = parseInt(config.delay);
+  }
+
+  let commands = [
+  	[option, iface, 'off'],
+	[option, iface, 'on']
+  ];
+  
+  let resp;
+  try {
+     resp = await execFile('networksetup', commands[0], { env });
+  } catch(err) {
+     callback && callback(err);
+  }
+  
+  if (delay!==0)
+    await sleep(delay*1000);
+  
+  execFile('networksetup', commands[1], { env }, function(err) {
+     callback && callback(err);
+  });	              
+}
+
+module.exports = function(config) {
+  return function(callback) {
+    if (callback) {
+      disconnect(config, callback);
+    } else {
+      return new Promise(function(resolve, reject) {
+        disconnect(config, function(err) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+  };
+};

--- a/src/wifi.js
+++ b/src/wifi.js
@@ -8,13 +8,15 @@ var linuxDelete = require('./linux-delete');
 var linuxGetCurrentConnections = require('./linux-current-connections');
 var linuxScan = require('./linux-scan.js');
 var macConnect = require('./mac-connect.js');
+var macDisconnect = require('./mac-disconnect.js');
 var macScan = require('./mac-scan.js');
 var macDelete = require('./mac-delete');
 var macGetCurrentConnections = require('./mac-current-connections');
 
 var config = {
   debug: false,
-  iface: null
+  iface: null,
+  delay: 0
 };
 
 function init(options) {
@@ -24,6 +26,10 @@ function init(options) {
 
   if (options && options.iface) {
     config.iface = options.iface;
+  }
+  
+  if (options && options.delay) {
+    config.delay = options.delay;
   }
 
   var scan = function() {
@@ -53,6 +59,7 @@ function init(options) {
     case 'darwin':
       connect = macConnect(config);
       scan = macScan(config);
+      disconnect = macDisconnect(config);
       deleteConnection = macDelete(config);
       getCurrentConnections = macGetCurrentConnections(config);
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Remember to follow CONTRIBUTING.md guidelines otherwise your pull request will be refused -->

## Description

<!--- Describe your changes in detail -->
I added a disconnect function by using CLI functions that do not require to be root. Those functions turn off the wifi first and, after an optional delay, turn it on again. Since disconnecting from a network or a device properly may require a delay, I included a sleep function to do it without generating a Promise, like a setTimeout would do.

## Motivation and Context

On Mac the disconnect was a missed functionality. 

## Usage examples

<!--- Provide examples of intended usage -->
const  WiFiControl = require('node-wifi');

WiFiControl.init({
	iface: null,
	debug: true,
	delay: 5 // delay in seconds
});
//....
WiFiControll.disconnect();

## How Has This Been Tested?

I tested on Mac version 10.14.6.

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
