### PR TITLE
Error when connect on a quasar electron app on mac

### DIFF
--- a/src/mac-connect.js
+++ b/src/mac-connect.js
@@ -12,7 +12,7 @@ function connectToWifi(config, ap, callback) {
   args.push(ap.ssid);
   args.push(ap.password);
 
-  execFile('networksetup', args, { env }, function(err, resp) {
+  execFile('/usr/sbin/networksetup', args, { env }, function(err, resp) {
     if (resp && resp.indexOf('Failed to join network') >= 0) {
       callback && callback(resp);
     } else if (resp && resp.indexOf('Could not find network') >= 0) {


### PR DESCRIPTION
[Related issue](https://github.com/quasarframework/quasar/issues/5495)

<!--- Provide a general summary of your changes in the Title above -->


<!--- Remember to follow CONTRIBUTING.md guidelines otherwise your pull request will be refused -->

## Description
The **connect** doesn't work on a mac when developing a [quasar](https://quasar.dev/quasar-cli/developing-electron-apps/introduction) electron application.
It doesn't work because when quasar launches the electron app (it uses [webpack](https://webpack.js.org/)) it doesn't have access to the same PATH, and so, node can't find the _networksetup_ tool.
<!--- Describe your changes in detail -->

## Motivation and Context
Motivation for this PR is that it won't change anything for "normal" electron users, but make win some useful time for quasar users (as for other frameworks of that kind). 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples
Nothing changes for end the usages of node-wifi library. 
<!--- Provide examples of intended usage -->

## How Has This Been Tested?
Need to have an quasar electron app to see that error. 
Tested as it is asked in test/README.md, using a .env file and running the tests (on a mac machine - Catalina). 

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
