### PR TITLE
Fix connections function to return proper mac address and not the bssid

### DIFF
--- a/src/windows-current-connections.js
+++ b/src/windows-current-connections.js
@@ -36,7 +36,7 @@ function parseShowInterfaces(stdout) {
       iface: tmpConnection['name'],
       ssid: tmpConnection['ssid'],
       bssid: tmpConnection['bssid'],
-      mac: tmpConnection['bssid'],
+      mac: tmpConnection['mac'],
       mode: tmpConnection['mode'],
       channel: parseInt(tmpConnection['channel']),
       frequency: parseInt(


### PR DESCRIPTION
## Description

Fixes incorrect mac address returned when getting connections information on windows, which actually returns the bssid instead.  

## Motivation and Context

Bugfix

## Usage examples

const wifi = require('node-wifi');
wifi.init({iface: 'wlan'});
wifi.getCurrentConnections().then(result => console.log(result));

// Compare with 'netsh wlan show interfaces'

## How Has This Been Tested?

Tested on Windows 10

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
