### PR TITLE
fix: linux scan and getCurrentConnections

### DIFF
--- a/src/linux-current-connections.js
+++ b/src/linux-current-connections.js
@@ -25,9 +25,6 @@ function getCurrentConnection(config, callback) {
     }
 
     var lines = scanResults.split('\n');
-    if (config.iface) {
-      lines.shift();
-    }
 
     var networks = [];
     for (var i = 0; i < lines.length; i++) {

--- a/src/linux-scan.js
+++ b/src/linux-scan.js
@@ -26,10 +26,6 @@ function scanWifi(config, callback) {
 
     var lines = scanResults.split('\n');
 
-    if (config.iface) {
-      lines.shift();
-    }
-
     var networks = [];
     for (var i = 0; i < lines.length; i++) {
       if (lines[i] != '' && lines[i].includes(':')) {


### PR DESCRIPTION
##  Motivation and Context
Fixes not full list of scanned networks and current connections on linux
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples
`wifi --scan`
`wifi --current`
## How Has This Been Tested?
Manual tests on Linux

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
