### PR TITLE
fix: wifi connect issue fix for Windows

### DIFF
--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -5,7 +5,7 @@ var scan = require('./windows-scan');
 
 function execCommand(cmd, params) {
   return new Promise(function(resolve, reject) {
-    execFile(cmd, params, { env }, function(err, stdout, stderr) {
+    execFile(cmd, params, { env, shell: true }, function(err, stdout, stderr) {
       if (err) {
         // Add command output to error, so it's easier to handle
         err.stdout = stdout;
@@ -44,7 +44,7 @@ function connectToWifi(config, ap, callback) {
       ]);
     })
     .then(function() {
-      var cmd = 'cmd';
+      var cmd = 'netsh';
       var params = [
         'wlan',
         'connect',


### PR DESCRIPTION
Fix for Wifi connect issue on Windows

## Motivation and Context
1.  Current windows connect implementation does not work due to wrong command usage. This PR fixes it.
2. Also, delete local profile file fail on Windows because of shell options missing in execFile call.
    Detail for the fix is explained here: https://stackoverflow.com/a/54515183/8592525

## How Has This Been Tested?

Manual testing on Windows 10.

Issue link: https://github.com/friedrith/node-wifi/issues/111

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
