### PR TITLE
docs: change registry config to see it in github page

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "prettier:fix": "prettier --write 'src/**/*.js'",
     "release": "standard-version"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/friedrith/node-wifi.git"


### PR DESCRIPTION
In order to see the registry in github page, the URL is provided in package.json

## Motivation and Context

With now several registry available (github, npm, etc), it may be useful to show the current registry used.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
