### PR TITLE
ci: split workflow in separated jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: test
 
 on:
   push:
@@ -10,13 +10,25 @@ on:
     branches: [master]
 
 jobs:
-  test:
+  lint:
+    name: lint
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format
 
+  unit_tests:
+    name: unit tests
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -24,6 +36,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run lint
-      - run: npm run format
       - run: npm test


### PR DESCRIPTION
## Description

For a better readibility in pull requests, the workflow is now renamed "test" and is splited in two jobs: lint and unit tests

## Motivation and Context

Previous workflow config had been generated by github and was not very understandable

## Usage examples

No impact on API.

## How Has This Been Tested?

Tested on CI

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactorization (non-functional change which improve code readibility)
