### PR TITLE
ci: rename workflow into build to prepare es6 modules import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: test
+name: build
 
 on:
   push:
@@ -23,8 +23,8 @@ jobs:
       - run: npm run lint
       - run: npm run format
 
-  unit_tests:
-    name: unit tests
+  test:
+    name: test
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description

Workflow is now called `build` instead of `test`.

## Motivation and Context

In the future, in order to use `import` syntax, javascript code should be built so the name build is more adapted.

## Usage examples

No API change

## How Has This Been Tested?

CI

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactorization (non-functional change which improve code readibility)
