### PR TITLE
refactor(linux): scan easier to read

### DIFF
--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -5,3 +5,7 @@ Curated list of useful documentation for this project:
 - [The-way-to-fully-automated-releases-in-open-source-projects](https://medium.com/@kevinkreuzer/the-way-to-fully-automated-releases-in-open-source-projects-44c015f38fd6)
 - [Travis tutorial](https://docs.travis-ci.com/user/tutorial/)
 - [Example for github templates](https://github.com/conventional-changelog/commitlint/blob/master/.github)
+
+## Linux
+
+- refresh scan: https://superuser.com/questions/164059/how-to-force-network-manager-to-rescan-connections

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ wifi --current
 This project is tested with operating systems:
 
 - macOS Catalina 10.15.5
+- linux Ubuntu 18.04.3 LTS
 
 > Do not hesitate to create a pull request to add the OS you are using.
 
@@ -165,7 +166,7 @@ This project is tested with operating systems:
 
 Linux:
 
-- network-manager
+- network-manager (nmcli)
 
 ## Contribute
 
@@ -184,5 +185,6 @@ Please read [development guidelines](./CONTRIBUTING.md) before proposing a pull 
 - [x] use github actions
 - [ ] add unit tests (in progress)
 - [ ] rewrite the library using ES7 (in progress)
+- [ ] harmonize security flags and modes
 - [ ] install commitizen
 - [ ] use xml to stabilize parsers

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,0 +1,11 @@
+# Hardware
+
+**node-wifi** has been tested on following hardwares.
+
+## macOS
+
+## Linux
+
+To get the device info: `lspci | egrep -i --color 'network|ethernet'`.
+
+- Dell XPS 13 2019 (9370): Qualcomm Atheros QCA6174 802.11ac Wireless Network Adapter (rev 32)

--- a/scripts/scan.js
+++ b/scripts/scan.js
@@ -1,7 +1,9 @@
 const execute = require('../src/utils/executer');
-const command = require('../src/macOS/scan/command');
+const platform = require('../src/platform');
 
-const { cmd, args } = command();
+const { command } = platform().scan;
+
+const { cmd, args } = command({ iface: null });
 
 console.log(`$ ${cmd} ${args.join(' ')}`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,34 @@
+const execute = require('./utils/executer');
+const promiser = require('./utils/promiser');
+
+const platform = require('./platform');
+
+let config = {
+  debug: false,
+  iface: null
+};
+
+const init = newConfig => {
+  config = {
+    ...config,
+    ...newConfig
+  };
+};
+
+const scan = () => {
+  if (!platform().scan) {
+    throw new Error('ERROR : not available for this OS');
+  }
+
+  const { command, parse } = platform().scan;
+
+  const scanWifi = config =>
+    execute(command(config)).then(output => parse(output));
+
+  return promiser(scanWifi);
+};
+
+module.exports = {
+  init,
+  scan
+};

--- a/src/linux-scan.js
+++ b/src/linux-scan.js
@@ -1,77 +1,9 @@
-var execFile = require('child_process').execFile;
-var networkUtils = require('./utils/network-utils');
-var env = require('./env');
+const execute = require('./utils/executer');
+const promiser = require('./utils/promiser');
+const command = require('./linux/scan/command.js');
+const parse = require('./linux/scan/parser');
 
-function scanWifi(config, callback) {
-  var args = [];
-  args.push('--terse');
-  args.push('--fields');
-  args.push(
-    'active,ssid,bssid,mode,chan,freq,signal,security,wpa-flags,rsn-flags'
-  );
-  args.push('device');
-  args.push('wifi');
-  args.push('list');
+const scanWifi = config =>
+  execute(command(config)).then(output => parse(output));
 
-  if (config.iface) {
-    args.push('ifname');
-    args.push(config.iface);
-  }
-
-  execFile('nmcli', args, { env }, function(err, scanResults) {
-    if (err) {
-      callback && callback(err);
-      return;
-    }
-
-    var lines = scanResults.split('\n');
-
-    var networks = [];
-    for (var i = 0; i < lines.length; i++) {
-      if (lines[i] != '' && lines[i].includes(':')) {
-        var fields = lines[i].replace(/\\:/g, '&&').split(':');
-        if (fields.length >= 9) {
-          networks.push({
-            ssid: fields[1].replace(/&&/g, ':'),
-            bssid: fields[2].replace(/&&/g, ':'),
-            mac: fields[2].replace(/&&/g, ':'), // for retrocompatibility with version 1.x
-            mode: fields[3].replace(/&&/g, ':'),
-            channel: parseInt(fields[4].replace(/&&/g, ':')),
-            frequency: parseInt(fields[5].replace(/&&/g, ':')),
-            signal_level: networkUtils.dBFromQuality(
-              fields[6].replace(/&&/g, ':')
-            ),
-            quality: parseFloat(fields[6].replace(/&&/g, ':')),
-            security:
-              fields[7].replace(/&&/g, ':') != '(none)'
-                ? fields[7].replace(/&&/g, ':')
-                : 'none',
-            security_flags: {
-              wpa: fields[8].replace(/&&/g, ':'),
-              rsn: fields[9].replace(/&&/g, ':')
-            }
-          });
-        }
-      }
-    }
-    callback && callback(null, networks);
-  });
-}
-
-module.exports = function(config) {
-  return function(callback) {
-    if (callback) {
-      scanWifi(config, callback);
-    } else {
-      return new Promise(function(resolve, reject) {
-        scanWifi(config, function(err, networks) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(networks);
-          }
-        });
-      });
-    }
-  };
-};
+module.exports = promiser(scanWifi);

--- a/src/linux/index.js
+++ b/src/linux/index.js
@@ -1,0 +1,3 @@
+const scan = require('./scan/index');
+
+module.exports = { scan };

--- a/src/linux/scan/__logs__/scan-01.log
+++ b/src/linux/scan/__logs__/scan-01.log
@@ -1,0 +1,16 @@
+$ nmcli --terse --fields active,ssid,bssid,mode,chan,freq,signal,security,wpa-flags,rsn-flags device wifi list
+no:Linksys01777:31\:23\:03\:1A\:9F\:1C:Infra:11:2462 MHz:100:WPA2:(none):pair_ccmp group_ccmp psk
+no:Linksys01777-invité:31\:23\:03\:18\:9F\:1C:Infra:11:2462 MHz:100::(none):(none)
+no:EBOX_6070:00\:21\:6A\:75\:60\:22:Infra:11:2462 MHz:100:WPA1 WPA2:pair_tkip pair_ccmp group_tkip psk:pair_tkip pair_ccmp group_tkip psk
+yes:Linksys01777_5GHz:31\:23\:03\:1A\:9F\:1D:Infra:36:5180 MHz:75:WPA2:(none):pair_ccmp group_ccmp psk
+no:NERMNET:61\:FF\:7B\:43\:B5\:27:Infra:1:2412 MHz:64:WPA2:(none):pair_tkip pair_ccmp group_tkip psk
+no:NERMNET:61\:FF\:7B\:43\:B5\:26:Infra:149:5745 MHz:64:WPA1 WPA2:pair_tkip pair_ccmp group_tkip psk:pair_tkip pair_ccmp group_tkip psk
+no:VIRGIN172:B1\:EE\:0E\:E4\:FA\:1E:Infra:6:2437 MHz:62:WPA2:(none):pair_ccmp group_ccmp psk
+no:NERMNET:91\:48\:27\:4B\:7C\:5A:Infra:13:2472 MHz:55:WPA1 WPA2:pair_tkip pair_ccmp group_tkip psk:pair_tkip pair_ccmp group_tkip psk
+no:VIRGIN660:D1\:D7\:75\:A2\:BC\:F6:Infra:6:2437 MHz:54:WPA2:(none):pair_ccmp group_ccmp psk
+no:VIDEOTRON9021:A1\:E4\:CB\:FB\:42\:38:Infra:11:2462 MHz:40:WPA2:(none):pair_ccmp group_ccmp psk
+no:BELL320:A1\:6A\:BB\:E9\:FC\:E7:Infra:44:5220 MHz:30:WPA2:(none):pair_ccmp group_ccmp psk
+no:BELL320:A1\:6A\:BB\:E9\:FC\:E5:Infra:100:5500 MHz:30:WPA2:(none):pair_ccmp group_ccmp psk
+no::A1\:6A\:BB\:E9\:FC\:E5:Infra:100:5500 MHz:30:WPA2:(none):pair_ccmp group_ccmp psk
+no:BELL320:A1\:6A\:BB\:E9\:FC\:E6:Infra:1:2412 MHz:25:WPA2:(none):pair_ccmp group_ccmp psk
+

--- a/src/linux/scan/__test__/command.spec.js
+++ b/src/linux/scan/__test__/command.spec.js
@@ -1,0 +1,33 @@
+const command = require('../command');
+
+describe('linux scan command', () => {
+  it('should generate basic command without iface', () => {
+    expect(command({ iface: null })).toEqual({
+      cmd: 'nmcli',
+      args: [
+        '--terse',
+        '--fields',
+        'active,ssid,bssid,mode,chan,freq,signal,security,wpa-flags,rsn-flags',
+        'device',
+        'wifi',
+        'list'
+      ]
+    });
+  });
+
+  it('should generate basic command with iface', () => {
+    expect(command({ iface: 'wlan0' })).toEqual({
+      cmd: 'nmcli',
+      args: [
+        '--terse',
+        '--fields',
+        'active,ssid,bssid,mode,chan,freq,signal,security,wpa-flags,rsn-flags',
+        'device',
+        'wifi',
+        'list',
+        'ifname',
+        'wlan0'
+      ]
+    });
+  });
+});

--- a/src/linux/scan/__test__/parser.spec.js
+++ b/src/linux/scan/__test__/parser.spec.js
@@ -1,0 +1,196 @@
+const path = require('path');
+const unlog = require('../../../__test__/unlogger');
+const parse = require('../parser');
+
+const log = filename => path.resolve(__dirname, `../__logs__/`, filename);
+
+describe('parse linux scan output', () => {
+  it('should return wifi networks', async () => {
+    const output = await unlog(log('scan-01.log'));
+
+    const networks = parse(output);
+
+    expect(networks).toEqual([
+      {
+        ssid: 'Linksys01777',
+        bssid: '31:23:03:1A:9F:1C',
+        mac: '31:23:03:1A:9F:1C',
+        mode: 'Infra',
+        channel: 11,
+        frequency: 2462,
+        signal_level: -50,
+        quality: 100,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'Linksys01777-invité',
+        bssid: '31:23:03:18:9F:1C',
+        mac: '31:23:03:18:9F:1C',
+        mode: 'Infra',
+        channel: 11,
+        frequency: 2462,
+        signal_level: -50,
+        quality: 100,
+        security: '',
+        security_flags: { wpa: '(none)', rsn: '(none)' }
+      },
+      {
+        ssid: 'EBOX_6070',
+        bssid: '00:21:6A:75:60:22',
+        mac: '00:21:6A:75:60:22',
+        mode: 'Infra',
+        channel: 11,
+        frequency: 2462,
+        signal_level: -50,
+        quality: 100,
+        security: 'WPA1 WPA2',
+        security_flags: {
+          wpa: 'pair_tkip pair_ccmp group_tkip psk',
+          rsn: 'pair_tkip pair_ccmp group_tkip psk'
+        }
+      },
+      {
+        ssid: 'Linksys01777_5GHz',
+        bssid: '31:23:03:1A:9F:1D',
+        mac: '31:23:03:1A:9F:1D',
+        mode: 'Infra',
+        channel: 36,
+        frequency: 5180,
+        signal_level: -62.5,
+        quality: 75,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'NERMNET',
+        bssid: '61:FF:7B:43:B5:27',
+        mac: '61:FF:7B:43:B5:27',
+        mode: 'Infra',
+        channel: 1,
+        frequency: 2412,
+        signal_level: -68,
+        quality: 64,
+        security: 'WPA2',
+        security_flags: {
+          wpa: '(none)',
+          rsn: 'pair_tkip pair_ccmp group_tkip psk'
+        }
+      },
+      {
+        ssid: 'NERMNET',
+        bssid: '61:FF:7B:43:B5:26',
+        mac: '61:FF:7B:43:B5:26',
+        mode: 'Infra',
+        channel: 149,
+        frequency: 5745,
+        signal_level: -68,
+        quality: 64,
+        security: 'WPA1 WPA2',
+        security_flags: {
+          wpa: 'pair_tkip pair_ccmp group_tkip psk',
+          rsn: 'pair_tkip pair_ccmp group_tkip psk'
+        }
+      },
+      {
+        ssid: 'VIRGIN172',
+        bssid: 'B1:EE:0E:E4:FA:1E',
+        mac: 'B1:EE:0E:E4:FA:1E',
+        mode: 'Infra',
+        channel: 6,
+        frequency: 2437,
+        signal_level: -69,
+        quality: 62,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'NERMNET',
+        bssid: '91:48:27:4B:7C:5A',
+        mac: '91:48:27:4B:7C:5A',
+        mode: 'Infra',
+        channel: 13,
+        frequency: 2472,
+        signal_level: -72.5,
+        quality: 55,
+        security: 'WPA1 WPA2',
+        security_flags: {
+          wpa: 'pair_tkip pair_ccmp group_tkip psk',
+          rsn: 'pair_tkip pair_ccmp group_tkip psk'
+        }
+      },
+      {
+        ssid: 'VIRGIN660',
+        bssid: 'D1:D7:75:A2:BC:F6',
+        mac: 'D1:D7:75:A2:BC:F6',
+        mode: 'Infra',
+        channel: 6,
+        frequency: 2437,
+        signal_level: -73,
+        quality: 54,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'VIDEOTRON9021',
+        bssid: 'A1:E4:CB:FB:42:38',
+        mac: 'A1:E4:CB:FB:42:38',
+        mode: 'Infra',
+        channel: 11,
+        frequency: 2462,
+        signal_level: -80,
+        quality: 40,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'BELL320',
+        bssid: 'A1:6A:BB:E9:FC:E7',
+        mac: 'A1:6A:BB:E9:FC:E7',
+        mode: 'Infra',
+        channel: 44,
+        frequency: 5220,
+        signal_level: -85,
+        quality: 30,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'BELL320',
+        bssid: 'A1:6A:BB:E9:FC:E5',
+        mac: 'A1:6A:BB:E9:FC:E5',
+        mode: 'Infra',
+        channel: 100,
+        frequency: 5500,
+        signal_level: -85,
+        quality: 30,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: '',
+        bssid: 'A1:6A:BB:E9:FC:E5',
+        mac: 'A1:6A:BB:E9:FC:E5',
+        mode: 'Infra',
+        channel: 100,
+        frequency: 5500,
+        signal_level: -85,
+        quality: 30,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      },
+      {
+        ssid: 'BELL320',
+        bssid: 'A1:6A:BB:E9:FC:E6',
+        mac: 'A1:6A:BB:E9:FC:E6',
+        mode: 'Infra',
+        channel: 1,
+        frequency: 2412,
+        signal_level: -87.5,
+        quality: 25,
+        security: 'WPA2',
+        security_flags: { wpa: '(none)', rsn: 'pair_ccmp group_ccmp psk' }
+      }
+    ]);
+  });
+});

--- a/src/linux/scan/command.js
+++ b/src/linux/scan/command.js
@@ -1,0 +1,22 @@
+const command = config => {
+  const args = [
+    '--terse',
+    '--fields',
+    'active,ssid,bssid,mode,chan,freq,signal,security,wpa-flags,rsn-flags',
+    'device',
+    'wifi',
+    'list'
+  ];
+
+  if (config.iface) {
+    args.push('ifname');
+    args.push(config.iface);
+  }
+
+  return {
+    cmd: 'nmcli',
+    args
+  };
+};
+
+module.exports = command;

--- a/src/linux/scan/index.js
+++ b/src/linux/scan/index.js
@@ -1,0 +1,4 @@
+const command = require('./command.js');
+const parse = require('./parser');
+
+module.exports = { command, parse };

--- a/src/linux/scan/parser.js
+++ b/src/linux/scan/parser.js
@@ -1,0 +1,51 @@
+const { dBFromPercentage } = require('../../utils/percentage-db');
+
+const matchBssid = line =>
+  line.match(
+    /[A-F0-9]{2}\\:[A-F0-9]{2}\\:[A-F0-9]{2}\\:[A-F0-9]{2}\\:[A-F0-9]{2}\\:[A-F0-9]{2}/
+  );
+
+const parse = stdout =>
+  stdout
+    .split('\n')
+    .filter(line => line !== '' && line.includes(':'))
+    .filter(line => matchBssid(line))
+    .map(line => {
+      const match = matchBssid(line);
+      const bssid = match[0].replace(/\\:/g, ':');
+
+      const fields = line.replace(match[0]).split(':');
+
+      const [
+        // eslint-disable-next-line no-unused-vars
+        active,
+        ssid,
+        // eslint-disable-next-line no-unused-vars
+        bssidAlreadyProcessed,
+        mode,
+        channel,
+        frequency,
+        quality,
+        security,
+        security_flags_wpa,
+        security_flags_rsn
+      ] = fields;
+
+      return {
+        ssid,
+        bssid,
+        mac: bssid, // for retrocompatibility with version 1.x
+        mode,
+        channel: parseInt(channel),
+        frequency: parseInt(frequency),
+        signal_level: dBFromPercentage(quality),
+        quality: parseInt(quality),
+        security: security !== '(none)' ? security : 'none',
+        security_flags: {
+          wpa: security_flags_wpa,
+          rsn: security_flags_rsn
+        }
+      };
+    });
+
+module.exports = parse;

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,0 +1,19 @@
+const linux = require('./linux/index');
+
+module.exports = () => {
+  let platform;
+
+  switch (process.platform) {
+    case 'linux':
+      platform = linux;
+      break;
+    case 'darwin':
+      break;
+    case 'win32':
+      break;
+    default:
+      throw new Error('ERROR : UNRECOGNIZED OS');
+  }
+
+  return platform;
+};


### PR DESCRIPTION
Code to scan wifi on linux is not easier to read and also tested.

It also introduce a new architecture to more easily manage all functions
from all platforms.

## Description

Use architecture based on folders and `command` and `parser`.

## Motivation and Context

It is easier to unitary tests parser and command generator.

## Usage examples

No change of interfaces.

## How Has This Been Tested?

Unit tests have been added

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactorization (non-functional change which improve code readibility)
