### PR TITLE
fix: windows wifi scan issue fix for first network

### DIFF
--- a/src/windows-scan.js
+++ b/src/windows-scan.js
@@ -19,7 +19,7 @@ function scanWifi(config, callback) {
           .split('\r')
           .join('')
           .split('\n')
-          .slice(5, scanResults.length);
+          .slice(4, scanResults.length);
 
         var numNetworks = -1;
         var currentLine = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Remember to follow CONTRIBUTING.md guidelines otherwise your pull request will be refused -->

## Description
While scanning for the networks in windows, initially there is a slicing from 5th index which leads to the omitting of first row depicting the ssid of the network.
Have changed the slicing from 4th index, so that all the network information be preserved and assigned correctly.

## Motivation and Context
This change is required as to get the correct information of the first network been captured and utilized.
https://github.com/friedrith/node-wifi/issues/137

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?
After the change, have tried to scan for the networks, and can see all the information for every network is been listed correctly.
Also tried to connect and disconnect with the selected network, which works as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactorization (non-functional change which improve code readibility)
