### PR TITLE
Add sudo and timeout options to linux-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ wifi.connect({ ssid: 'ssid', password: 'password' }, error => {
   console.log('Connected');
 });
 
+// You can use sudo (need sudoer permission) or set timeout on linux
+wifi.connect({ ssid: 'ssid', password: 'password', sudo: true, timeout: 10 /* seconds */ }, error => {
+  if (error) {
+    console.log(error);
+  }
+  console.log('Connected');
+});
+
 // Disconnect from a network
 // not available on all os for now
 wifi.disconnect(error => {

--- a/src/linux-connect.js
+++ b/src/linux-connect.js
@@ -2,9 +2,14 @@ var execFile = require('child_process').execFile;
 var env = require('./env');
 
 function connectToWifi(config, ap, callback) {
+  let timeout = parseInt(ap.timeout, 10);
+  if (Number.isNaN(timeout) || timeout < 0) {
+    timeout = 10;
+  }
+
   var args = [];
   args.push('-w');
-  args.push('10');
+  args.push(`${timeout}`);
   args.push('device');
   args.push('wifi');
   args.push('connect');
@@ -17,7 +22,13 @@ function connectToWifi(config, ap, callback) {
     args.push(config.iface);
   }
 
-  execFile('nmcli', args, { env: env }, function(err, resp) {
+  let file = 'nmcli';
+  if (ap.sudo) {
+    args.unshift(file);
+    file = 'sudo';
+  }
+
+  execFile(file, args, { env: env }, function(err, resp) {
     // Errors from nmcli came from stdout, we test presence of 'Error: ' string
     if (resp.includes('Error: ')) {
       err = new Error(resp.replace('Error: ', ''));

--- a/test/test-connect.js
+++ b/test/test-connect.js
@@ -3,29 +3,29 @@ require('dotenv').config();
 var wifi = require('../src/wifi');
 
 wifi.init({
-    debug : true,
-    iface : process.env.WIFI_IFACE
+  debug: true,
+  iface: process.env.WIFI_IFACE,
 });
 
 var ap = {
-    ssid : process.env.WIFI_SSID,
-    password : process.env.WIFI_PASSWORD
+  ssid: process.env.WIFI_SSID,
+  password: process.env.WIFI_PASSWORD,
 }
 
 if (process.env.PROMISE == "true") {
   console.log('with promise');
-  wifi.connect(ap, function(err) {
-      if (err) {
-          console.log(err);
-      } else {
-          console.log('connected');
-      }
-  });
-} else {
-  console.log('with callback');
-  wifi.connect(ap).then(function () {
+  wifi.connect(ap).then(function() {
     console.log('connected');
-  }).catch(function (e) {
+  }).catch(function(e) {
     console.log(e);
   })
+} else {
+  console.log('with callback');
+  wifi.connect(ap, function(err) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log('connected');
+    }
+  });
 }

--- a/test/test-linux-connect.js
+++ b/test/test-linux-connect.js
@@ -1,0 +1,34 @@
+require('dotenv').config();
+
+const config = {
+  debug : true,
+  iface : process.env.WIFI_IFACE
+};
+
+const connect = require('../src/linux-connect')(config);
+
+var ap = {
+  ssid : process.env.WIFI_SSID,
+  password : process.env.WIFI_PASSWORD,
+  sudo : process.env.SUDO,
+  timeout : process.env.TIMEOUT,
+}
+
+if (process.env.PROMISE == "true") {
+  console.log('with promise');
+  connect(ap).then(function () {
+    console.log('connected');
+  }).catch(function (e) {
+    console.log(e);
+  })
+} else {
+  console.log('with callback');
+  connect(ap, function(err) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log('connected');
+    }
+  });
+}
+


### PR DESCRIPTION
Allow users to use the connect method with sudo permission or customize waiting timeout on Linux.

## Description
I use the connect code example on Raspberry Pi 4.

```js
// connect.js
wifi.connect({ ssid: 'ssid', password: 'password' }, error => {
  if (error) {
    console.log(error);
  }
  console.log('Connected');
});
```

It works by using `node connect.js`

When I use `pm2 start connect.js`, the permission error was thrown.

Not sure what's the root cause yet, but using sudo can be a workaround to solve this issue.

## Motivation and Context

Related issue: #10 

## Usage examples

```js
// You can use sudo (need sudoer permission) or set timeout on linux
wifi.connect({ ssid: 'ssid', password: 'password', sudo: true, timeout: 10 /* seconds */ }, error => {
  if (error) {
    console.log(error);
  }
  console.log('Connected');
});
```

## How Has This Been Tested?
Tested on Raspberry Pi 4, Raspbian OS

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactorization (non-functional change which improve code readability)
