### PR TITLE
Windows 11 support for `getCurrentConnections` (fix parsing)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ To keep the code base of commitlint neat and tidy the following rules apply to e
 - Favor micro library over swiss army knives (rimraf, ncp vs. fs-extra)
 - Be awesome
 
-> use commands `npm run eslint` and `npm run format` to be sure your code
+> use commands `npm run lint` and `npm run format` to be sure your code
 > respect coding rules.
 
 > You can also use `npm run format:fix` to fix prettier errors

--- a/src/windows-current-connections.js
+++ b/src/windows-current-connections.js
@@ -1,32 +1,64 @@
+const os = require('os');
 const execFile = require('child_process').execFile;
 const env = require('./env');
 const networkUtils = require('./utils/network-utils.js');
 
+function isWin11() {
+  const winMajor = os.release().split('.')[0];
+  const winMinor = os.release().split('.')[1];
+  const winBuild = os.release().split('.')[2];
+  return winMajor >= 10 && winMinor >= 0 && winBuild >= 22000;
+}
+
 function parseShowInterfaces(stdout) {
   const lines = stdout.split('\r\n');
+  const numberOfLines = isWin11() ? 20 : 18;
   const connections = [];
   let i = 3;
-  while (lines.length > i + 18) {
+  while (lines.length > i + numberOfLines) {
     const tmpConnection = {};
-    const fields = [
-      'name',
-      'description',
-      'guid',
-      'mac',
-      'state',
-      'ssid',
-      'bssid',
-      'mode',
-      'radio',
-      'authentication',
-      'encryption',
-      'connection',
-      'channel',
-      'reception',
-      'transmission',
-      'signal',
-      'profil'
-    ];
+    const fields = isWin11()
+      ? [
+          'name',
+          'description',
+          'guid',
+          'mac',
+          'ifaceType',
+          'state',
+          'ssid',
+          'bssid',
+          'mode',
+          'radio',
+          'authentication',
+          'encryption',
+          'connection',
+          'band',
+          'channel',
+          'reception',
+          'transmission',
+          'signal',
+          'profile'
+        ]
+      : [
+          // else Windows 10
+          'name',
+          'description',
+          'guid',
+          'mac',
+          'state',
+          'ssid',
+          'bssid',
+          'mode',
+          'radio',
+          'authentication',
+          'encryption',
+          'connection',
+          'channel',
+          'reception',
+          'transmission',
+          'signal',
+          'profile'
+        ];
     for (let j = 0; j < fields.length; j++) {
       const line = lines[i + j];
       tmpConnection[fields[j]] = line.match(/.*: (.*)/)[1];
@@ -48,7 +80,7 @@ function parseShowInterfaces(stdout) {
       security_flags: tmpConnection.encryption
     });
 
-    i = i + 18;
+    i = i + numberOfLines;
   }
 
   return connections;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Remember to follow CONTRIBUTING.md guidelines otherwise your pull request will be refused -->

## Description

<!--- Describe your changes in detail -->
Windows 11 has two more fields in `netsh wlan show interfaces`: Interface Type (`ifaceType`) and Band (`band`). This made the parsing break so `.getCurrentConnections()` would return its values on the wrong keys for the resulting object.

Also made a few quick typo corrections.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #176 

## Usage examples

<!--- Provide examples of intended usage -->
Use `.getCurrentConnections()` in Windows 11.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I tested getting the current connections and the object would now make sense.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactorization (non-functional change which improve code readibility)
