### PR TITLE
Support hidden wifi on windows

### DIFF
--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -23,58 +23,64 @@ function execCommand(cmd, params) {
 }
 
 function connectToWifi(config, ap, callback) {
-  scan(config)()
-    .then(networks => {
-      const selectedAp = networks.find(network => {
+  let selectedAp = null;
+  let profile;
+  if (ap.hiddenWifi) {
+    selectedAp = {
+      ssid: ap.ssid,
+      security: ['WPA2'],
+    };
+
+    profile = Promise.resolve(selectedAp);
+  } else {
+    profile = scan(config)().then(networks => {
+      selectedAp = networks.find(network => {
         return network.ssid === ap.ssid;
       });
+    });
+  }
 
-      if (selectedAp === undefined) {
-        throw 'SSID not found';
-      }
+  if (selectedAp === undefined) {
+    throw 'SSID not found';
+  }
+  fs.writeFileSync(
+      profileFilename,
+      win32WirelessProfileBuilder(selectedAp, ap.password, ap.hiddenWifi),
+  );
 
-      fs.writeFileSync(
-        profileFilename,
-        win32WirelessProfileBuilder(selectedAp, ap.password)
-      );
-    })
-    .then(() => {
-      return execCommand('netsh', [
-        'wlan',
-        'add',
-        'profile',
-        `filename=${profileFilename}`
-      ]);
-    })
-    .then(() => {
-      const cmd = 'netsh';
-      const params = [
-        'wlan',
-        'connect',
-        `ssid="${ap.ssid}"`,
-        `name="${ap.ssid}"`
-      ];
-      if (config.iface) {
-        params.push(`interface="${config.iface}"`);
-      }
-      return execCommand(cmd, params);
-    })
-    .then(() => {
-      return execCommand(`del ${profileFilename}`);
-    })
-    .then(() => {
-      callback && callback();
-    })
-    .catch(err => {
-      execFile(
+  profile.then(() => {
+    return execCommand('netsh', [
+      'wlan',
+      'add',
+      'profile',
+      `filename=${profileFilename}`,
+    ]);
+  }).then(() => {
+    const cmd = 'netsh';
+    const params = [
+      'wlan',
+      'connect',
+      `ssid="${ap.ssid}"`,
+      `name="${ap.ssid}"`,
+    ];
+    if (config.iface) {
+      params.push(`interface="${config.iface}"`);
+    }
+    return execCommand(cmd, params);
+  }).then(() => {
+    return execCommand(`del ${profileFilename}`);
+  }).then(() => {
+    callback && callback();
+  }).catch(err => {
+    execFile(
         'netsh',
         ['wlan', 'delete', `profile "${ap.ssid}"`],
-        { env },
+        {env},
         () => {
           callback && callback(err);
         }
-      );
-    });
+    );
+  });
 }
 
 function getHexSsid(plainTextSsid) {
@@ -93,12 +99,21 @@ function getHexSsid(plainTextSsid) {
   return hex;
 }
 
-function win32WirelessProfileBuilder(selectedAp, key) {
-  let profile_content = `<?xml version="1.0"?> <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1"> <name>${
-    selectedAp.ssid
-  }</name> <SSIDConfig> <SSID> <hex>${getHexSsid(
-    selectedAp.ssid
-  )}</hex> <name>${selectedAp.ssid}</name> </SSID> </SSIDConfig>`;
+function win32WirelessProfileBuilder(selectedAp, key, hiddenWifi = false) {
+  let profile_content = `
+  <?xml version="1.0"?> <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+    <name>${ selectedAp.ssid }</name>
+    <SSIDConfig>
+     <SSID>
+       <hex>
+         ${getHexSsid(selectedAp.ssid,)}
+       </hex>
+       <name>${selectedAp.ssid}</name> 
+     </SSID>
+     <nonBroadcast>
+       ${hiddenWifi ?'true' : 'false'}
+     </nonBroadcast>
+    </SSIDConfig>`;
 
   if (selectedAp.security.includes('WPA2')) {
     profile_content += `<connectionType>ESS</connectionType> <connectionMode>auto</connectionMode> <autoSwitch>true</autoSwitch> <MSM> <security> <authEncryption> <authentication>WPA2PSK</authentication> <encryption>AES</encryption> <useOneX>false</useOneX> </authEncryption> <sharedKey> <keyType>passPhrase</keyType> <protected>false</protected> <keyMaterial>${key}</keyMaterial> </sharedKey> </security> </MSM>`;

--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -43,10 +43,6 @@ function connectToWifi(config, ap, callback) {
   if (selectedAp === undefined) {
     throw 'SSID not found';
   }
-  fs.writeFileSync(
-    profileFilename,
-    win32WirelessProfileBuilder(selectedAp, ap.password, ap.hiddenWifi)
-  );
 
   fs.writeFile(
     profileFilename,

--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -100,20 +100,13 @@ function getHexSsid(plainTextSsid) {
 }
 
 function win32WirelessProfileBuilder(selectedAp, key, hiddenWifi = false) {
-  let profile_content = `
-  <?xml version="1.0"?> <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
-    <name>${ selectedAp.ssid }</name>
-    <SSIDConfig>
-     <SSID>
-       <hex>
-         ${getHexSsid(selectedAp.ssid,)}
-       </hex>
-       <name>${selectedAp.ssid}</name> 
-     </SSID>
-     <nonBroadcast>
-       ${hiddenWifi ?'true' : 'false'}
-     </nonBroadcast>
-    </SSIDConfig>`;
+  let profile_content = `<?xml version="1.0"?> <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1"> <name>${
+    selectedAp.ssid
+  }</name> <SSIDConfig> <SSID> <hex>${getHexSsid(
+    selectedAp.ssid
+  )}</hex> <name>${selectedAp.ssid}</name> </SSID> ${
+    hiddenWifi ? '<nonBroadcast>true</nonBroadcast>' : ''
+  } </SSIDConfig>`;
 
   if (selectedAp.security.includes('WPA2')) {
     profile_content += `<connectionType>ESS</connectionType> <connectionMode>auto</connectionMode> <autoSwitch>true</autoSwitch> <MSM> <security> <authEncryption> <authentication>WPA2PSK</authentication> <encryption>AES</encryption> <useOneX>false</useOneX> </authEncryption> <sharedKey> <keyType>passPhrase</keyType> <protected>false</protected> <keyMaterial>${key}</keyMaterial> </sharedKey> </security> </MSM>`;

--- a/src/windows-connect.js
+++ b/src/windows-connect.js
@@ -25,7 +25,7 @@ function execCommand(cmd, params) {
 function connectToWifi(config, ap, callback) {
   let selectedAp = null;
   let profile;
-  if (ap.hiddenWifi) {
+  if (ap.isHidden) {
     selectedAp = {
       ssid: ap.ssid,
       security: ['WPA2']
@@ -46,7 +46,7 @@ function connectToWifi(config, ap, callback) {
 
   fs.writeFile(
     profileFilename,
-    win32WirelessProfileBuilder(selectedAp, ap.password, ap.hiddenWifi),
+    win32WirelessProfileBuilder(selectedAp, ap.password, ap.isHidden),
     err => {
       if (err) {
         return Promise.reject(err);
@@ -109,13 +109,13 @@ function getHexSsid(plainTextSsid) {
   return hex;
 }
 
-function win32WirelessProfileBuilder(selectedAp, key, hiddenWifi = false) {
+function win32WirelessProfileBuilder(selectedAp, key, isHidden = false) {
   let profile_content = `<?xml version="1.0"?> <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1"> <name>${
     selectedAp.ssid
   }</name> <SSIDConfig> <SSID> <hex>${getHexSsid(
     selectedAp.ssid
   )}</hex> <name>${selectedAp.ssid}</name> </SSID> ${
-    hiddenWifi ? '<nonBroadcast>true</nonBroadcast>' : ''
+    isHidden ? '<nonBroadcast>true</nonBroadcast>' : ''
   } </SSIDConfig>`;
 
   if (selectedAp.security.includes('WPA2')) {


### PR DESCRIPTION
## Description

This PR add support for hidden wifis, wifis which do not broadcast there SSID, without breaking existing API usages.

## Motivation and Context

Windows does not simply connect to wifis which do not broadcast their SSID (hidden wifis).
The additional flag `<nonBroadcast>true</nonBroadcast>` in the profile xml file is required.


If the flag is set, this PR adds the nonBroadcast param to the profile xml config file and connects to the wifi.
It also skips the scan for the given wifi because it will not appear in the wifi list, obviously.

This PR is related and should close #22 on Windows.

The missing configuration has been posted on Stackoverflow in this thread:
https://stackoverflow.com/questions/69470100/connect-to-hidden-wifi-using-netsh-commands

## Usage examples

Users can now provide an additional parameter to the `connect()` method:
```js
nodeWifi.connect({ssid: 'foo', password: 'bar', isHidden?: true})
```
the default of isHidden is false so that existing code should not break.

## How Has This Been Tested?

The code has been tested on Windows 10 with a Wifi without SSID.

## Types of changes


- [x] New feature (non-breaking change which adds functionality)

- [x] Refactorization (non-functional change which improve code readibility)
